### PR TITLE
Fix Codex MCP handshake timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm run build
 npm start
 ```
 
-## Wiring Codex
+## Wiring with Codex CLI
 
 Copy-paste and adjust the absolute path to your build output:
 
@@ -174,12 +174,15 @@ If `codex` is missing, the result includes a clear error with next steps.
 
 ## Troubleshooting
 
+### MCP timeouts
+- Ensure the config uses an **absolute path** to `dist/codex-subagents.mcp.js`.
+- Verify no logs are written to stdout; set `DEBUG_MCP=1` to log timing to stderr.
+- If Codex CLI still hangs, run with `DEBUG_MCP=1` and check that `initialized` appears promptly (<2s).
+
+### Misc
 - “codex not found”: Install Codex CLI and ensure it is on PATH. Re-run `npm run e2e`.
-- No output: Check that your profiles in `~/.codex/config.toml` match the names used by this server (`reviewer`, `debugger`, `security`).
+- No output: Check that your profiles in `~/.codex/config.toml` match the names used by this server.
 - Large repos: Prefer `git worktree` over `mirror_repo=true` (see `docs/INTEGRATION.md`).
-- MCP hangs: ensure the config uses an **absolute path** to `dist/codex-subagents.mcp.js`.
-- Logs break handshake: only JSON-RPC frames go to stdout; set `DEBUG_MCP=1` for stderr diagnostics.
-- Slow start: agents on disk are loaded lazily after initialization.
 
 ## Docs
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/codex-subagents.mcp.js",
     "lint": "eslint . --ext .ts",
     "test": "vitest run",
-    "e2e": "tsx scripts/e2e-demo.ts"
+    "e2e": "bash scripts/e2e.sh"
   },
   "keywords": [
     "mcp",

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the project
+npm run build >/tmp/e2e-build.log && tail -n 20 /tmp/e2e-build.log
+
+# Temporary home with Codex config
+TMP_HOME="$(mktemp -d)"
+CONFIG_DIR="$TMP_HOME/.codex"
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_DIR/config.toml" <<CFG
+[mcp_servers.subagents]
+command = "node"
+args = ["$(pwd)/dist/codex-subagents.mcp.js"]
+
+[profiles.default]
+model = "gpt-4o-mini"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+CFG
+
+export HOME="$TMP_HOME"
+export OPENAI_API_KEY="${OPENAI_API_KEY:?}"
+
+# 1. list MCP servers and assert ours is present
+codex exec '/mcp' | tee "$TMP_HOME/mcp.txt"
+grep -q 'codex-subagents' "$TMP_HOME/mcp.txt"
+
+# 2. delegate to an existing agent
+codex exec 'subagents.delegate(agent="devops", task="Say hello from devops")' | tee "$TMP_HOME/delegate.txt"
+# ensure we got some output
+if [ ! -s "$TMP_HOME/delegate.txt" ]; then
+  echo "delegate returned no output" >&2
+  exit 1
+fi

--- a/src/codex-subagents.mcp.ts
+++ b/src/codex-subagents.mcp.ts
@@ -17,6 +17,7 @@ import { z } from 'zod';
 
 const SERVER_NAME = 'codex-subagents';
 const SERVER_VERSION = '0.1.0';
+const startTime = Date.now();
 
 // Personas and profiles
 type AgentKey = 'reviewer' | 'debugger' | 'security';
@@ -359,19 +360,29 @@ class TinyMCPServer {
     }
   }
 
-  private writeMessage(obj: JsonRpcResponse) {
+  private write(obj: unknown) {
     const payload = Buffer.from(JSON.stringify(obj), 'utf8');
     const header = Buffer.from(`Content-Length: ${payload.length}\r\n\r\n`, 'utf8');
     process.stdout.write(header);
     process.stdout.write(payload);
   }
 
+  private writeMessage(obj: JsonRpcResponse) {
+    this.write(obj);
+  }
+
+  private writeNotification(method: string, params?: unknown) {
+    this.write({ jsonrpc: '2.0', method, params });
+  }
+
   private async handleRequest(req: JsonRpcRequest) {
+    const isNotification = req.id === undefined;
     const id = req.id ?? null;
     try {
       if (req.method === 'initialize') {
+        const now = Date.now();
         if (process.env.DEBUG_MCP) {
-          console.error(`[${new Date().toISOString()}] initialize received`);
+          console.error(`[${new Date().toISOString()}] initialize received (${now - startTime}ms)`);
         }
         const result = {
           protocolVersion: '2024-11-05',
@@ -379,6 +390,10 @@ class TinyMCPServer {
           serverInfo: { name: this.name, version: this.version },
         };
         this.writeMessage({ jsonrpc: '2.0', id, result });
+        this.writeNotification('initialized');
+        if (process.env.DEBUG_MCP) {
+          console.error(`[${new Date().toISOString()}] initialized sent (${Date.now() - startTime}ms)`);
+        }
         return;
       }
       if (req.method === 'tools/list') {
@@ -430,19 +445,23 @@ class TinyMCPServer {
         return;
       }
 
-      // Default: method not found
-      this.writeMessage({
-        jsonrpc: '2.0',
-        id,
-        error: { code: -32601, message: `Method not found: ${req.method}` },
-      });
+      if (!isNotification) {
+        // Default: method not found
+        this.writeMessage({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32601, message: `Method not found: ${req.method}` },
+        });
+      }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      this.writeMessage({
-        jsonrpc: '2.0',
-        id,
-        error: { code: -32000, message: msg },
-      });
+      if (!isNotification) {
+        this.writeMessage({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32000, message: msg },
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- send `initialized` notification and ignore client notifications
- add DEBUG_MCP timing logs and stdio helpers
- document Codex CLI wiring and MCP timeout troubleshooting
- add non-interactive e2e script

## Testing
- `npm test`
- `npm run lint`
- `OPENAI_API_KEY=sk-test npm run e2e` *(fails: MCP client for `subagents` failed to start: request timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e5cccb9883278cdc4edbe344fb29