### PR TITLE
fix: include custom agents in list_agents via __dirname fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,7 @@ The format is based on Keep a Changelog and this project adheres to SemVer.
 - Zod-validated parameters and isolated temp workdir with persona injection.
 - Build scripts, linting, tests, and e2e demo script.
 - Documentation: README, INTEGRATION, SECURITY, OPERATIONS, ROADMAP.
+## [Unreleased]
+### Fixed
+- `list_agents` now reliably includes custom agents when Codex launches the MCP server from a different CWD by adding a fallback search to `dist/../agents` (alongside the installed binary). This prevents mismatches between `tools.call name=list_agents` and the `agents/` directory contents.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm start
 
 ## Wiring with Codex CLI
 
-Build the server and point Codex at the **absolute** path to the compiled entrypoint. Pass the agents directory explicitly so the server doesn't scan until after the handshake:
+ Build the server and point Codex at the **absolute** path to the compiled entrypoint. Pass the agents directory explicitly so the server doesn't scan until after the handshake. The server also falls back to an `agents/` folder adjacent to the installed binary (e.g. `dist/../agents`) if `--agents-dir` and `CODEX_SUBAGENTS_DIR` are not provided:
 
 ```
 # ~/.codex/config.toml

--- a/src/codex-subagents.mcp.ts
+++ b/src/codex-subagents.mcp.ts
@@ -136,7 +136,11 @@ export function mirrorRepoIfRequested(srcCwd: string | undefined, dest: string, 
 }
 
 // -------- Dynamic agents loading from directory --------
-export function getAgentsDir(argv: string[] = process.argv, env = process.env): string | undefined {
+export function getAgentsDir(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+  currentDir: string = process.cwd(),
+): string | undefined {
   const fromArg = argv.find((a) => a.startsWith('--agents-dir'));
   if (fromArg) {
     const parts = fromArg.split('=');
@@ -148,8 +152,8 @@ export function getAgentsDir(argv: string[] = process.argv, env = process.env): 
   // Common defaults. Prefer explicit, then CWD, then next to the installed server binary.
   const candidates = [
     // Project-local defaults
-    join(process.cwd(), 'agents'),
-    join(process.cwd(), '.codex-subagents', 'agents'),
+    join(currentDir, 'agents'),
+    join(currentDir, '.codex-subagents', 'agents'),
     // Fallback: alongside the installed server (dist/../agents or src/../agents)
     join(__dirname, '..', 'agents'),
   ];

--- a/src/codex-subagents.mcp.ts
+++ b/src/codex-subagents.mcp.ts
@@ -145,10 +145,13 @@ export function getAgentsDir(argv: string[] = process.argv, env = process.env): 
     if (idx >= 0 && argv[idx + 1]) return argv[idx + 1];
   }
   if (env.CODEX_SUBAGENTS_DIR) return env.CODEX_SUBAGENTS_DIR;
-  // Common defaults
+  // Common defaults. Prefer explicit, then CWD, then next to the installed server binary.
   const candidates = [
+    // Project-local defaults
     join(process.cwd(), 'agents'),
     join(process.cwd(), '.codex-subagents', 'agents'),
+    // Fallback: alongside the installed server (dist/../agents or src/../agents)
+    join(__dirname, '..', 'agents'),
   ];
   for (const c of candidates) {
     if (existsSync(c)) return c;

--- a/tests/getAgentsDir.test.ts
+++ b/tests/getAgentsDir.test.ts
@@ -1,29 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { getAgentsDir } from '../src/codex-subagents.mcp';
 import { existsSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
 
 describe('getAgentsDir resolution', () => {
-  it('falls back to server-adjacent agents/ when CWD has none', () => {
-    const originalCwd = process.cwd();
-    const isolated = join(tmpdir(), `cwd-${Date.now()}`);
-    try {
-      // Move to an empty tmp dir so CWD-based detection does not trigger
-      // (intentionally not creating agents/ there).
-      process.chdir(isolated);
-    } catch {
-      // If chdir fails, skip test gracefully.
-      return;
-    }
-    try {
-      const resolved = getAgentsDir([], {} as unknown as NodeJS.ProcessEnv);
-      expect(resolved).toBeDefined();
-      expect(resolved?.endsWith('agents')).toBe(true);
-      expect(existsSync(resolved!)).toBe(true);
-    } finally {
-      process.chdir(originalCwd);
-    }
+  it('resolves an existing agents directory', () => {
+    const resolved = getAgentsDir([], {} as unknown as NodeJS.ProcessEnv);
+    expect(resolved).toBeDefined();
+    expect(resolved?.endsWith('agents')).toBe(true);
+    expect(existsSync(resolved!)).toBe(true);
   });
 });
-

--- a/tests/getAgentsDir.test.ts
+++ b/tests/getAgentsDir.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { getAgentsDir } from '../src/codex-subagents.mcp';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('getAgentsDir resolution', () => {
+  it('falls back to server-adjacent agents/ when CWD has none', () => {
+    const originalCwd = process.cwd();
+    const isolated = join(tmpdir(), `cwd-${Date.now()}`);
+    try {
+      // Move to an empty tmp dir so CWD-based detection does not trigger
+      // (intentionally not creating agents/ there).
+      process.chdir(isolated);
+    } catch {
+      // If chdir fails, skip test gracefully.
+      return;
+    }
+    try {
+      const resolved = getAgentsDir([], {} as unknown as NodeJS.ProcessEnv);
+      expect(resolved).toBeDefined();
+      expect(resolved?.endsWith('agents')).toBe(true);
+      expect(existsSync(resolved!)).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});
+

--- a/tests/getAgentsDir.test.ts
+++ b/tests/getAgentsDir.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { getAgentsDir } from '../src/codex-subagents.mcp';
-import { existsSync } from 'fs';
+import { existsSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 describe('getAgentsDir resolution', () => {
-  it('resolves an existing agents directory', () => {
-    const resolved = getAgentsDir([], {} as unknown as NodeJS.ProcessEnv);
+  it('falls back to server-adjacent agents/ when cwd has none (no arg, no env)', () => {
+    const emptyCwd = mkdtempSync(join(tmpdir(), 'no-agents-'));
+    const resolved = getAgentsDir([], {} as unknown as NodeJS.ProcessEnv, emptyCwd);
     expect(resolved).toBeDefined();
     expect(resolved?.endsWith('agents')).toBe(true);
     expect(existsSync(resolved!)).toBe(true);


### PR DESCRIPTION
This PR fixes a mismatch where `tools.call name=list_agents` could omit agents defined in the `agents/` directory when the MCP server is launched with a different CWD.\n\nChanges:\n- Update `getAgentsDir` to fall back to `__dirname/../agents` (next to the installed server binary) when CWD-based paths are absent.\n- Add unit test covering the fallback resolution.\n- Update README to document fallback behavior.\n- Update CHANGELOG with a fix note under [Unreleased].\n\nValidation:\n- `npm test` passes.\n- `npm run build` OK.\n- Manual check: `require('dist/codex-subagents.mcp.js').getAgentsDir([], {})` resolves to repo `agents/`.\n\nCloses: n/a