### PR TITLE
Orchestration logging, auto‑injected delegation context, structured MCP errors; docs + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ MARKETING.md
 RELEASE_CHECKLIST.md
 
 orchestration/
+
+.tmp/

--- a/agents/a11y.md
+++ b/agents/a11y.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/analytics.md
+++ b/agents/analytics.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/api.md
+++ b/agents/api.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/coach.md
+++ b/agents/coach.md
@@ -17,3 +17,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. End with one next action that takes ≤5 minutes. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/copy.md
+++ b/agents/copy.md
@@ -15,3 +15,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Provide copy blocks keyed by screen/section. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/custdev.md
+++ b/agents/custdev.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -17,3 +17,7 @@ Constraints:
 
 Permissions inherit from the calling conversation. Align with `approval_policy: on-request`, `sandbox_mode: workspace-write` in Codex profiles.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/devops.md
+++ b/agents/devops.md
@@ -17,3 +17,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Provide YAML, Fastlane files, and step‑by‑step release commands. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/docs.md
+++ b/agents/docs.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Output Markdown files and a docs nav. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/git.md
+++ b/agents/git.md
@@ -15,3 +15,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Output ready‑to‑paste messages. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/ios.md
+++ b/agents/ios.md
@@ -24,3 +24,7 @@ Shared Protocol — Output Contract:
 
 Follow the Shared Protocol. Prefer code blocks per file with full paths (e.g., `App/Sources/Features/Onboarding/OnboardingView.swift`). Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/obsidian.md
+++ b/agents/obsidian.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Output `.md` templates and Dataview snippets. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -20,7 +20,7 @@ When thinking between delegations, emit structured, single-line markers so the s
 Keep them terse and action-oriented; one thought per line.
 
 ## Logging Policy
-- Call `tools.call name=log_event` for `request_started` and `request_completed`.
+- The server emits request lifecycle events; do not log `request_started`/`request_completed` here.
 - For each planned step, log `step_started`, `step_update`, and `step_completed` or `step_error` with your `run_id` and a unique `step_id`.
 - Pass `{ run_id, parent_step_id, step_idx }` to sub-agent delegates so they can log.
 - Summaries must be concise and redact secrets.

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -18,3 +18,9 @@ When thinking between delegations, emit structured, single-line markers so the s
 - [[ORCH-NOTE]] Any brief operational note
 
 Keep them terse and action-oriented; one thought per line.
+
+## Logging Policy
+- Call `tools.call name=log_event` for `request_started` and `request_completed`.
+- For each planned step, log `step_started`, `step_update`, and `step_completed` or `step_error` with your `run_id` and a unique `step_id`.
+- Pass `{ run_id, parent_step_id, step_idx }` to sub-agent delegates so they can log.
+- Summaries must be concise and redact secrets.

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -10,3 +10,11 @@ Prefer parallel for independent work; sequential for dependencies.
 Summarize after each batch, decide next steps, stop when the user goal is achieved.
 Never delegate without the token; refuse and explain if token is missing.
 Non-orchestrator agents must not delegate; they perform local work only.
+
+When thinking between delegations, emit structured, single-line markers so the server can log your reasoning timeline:
+
+- [[ORCH-THINK]] {"text":"short internal rationale or hypothesis"}
+- [[ORCH-DECISION]] {"text":"what to do next and why"}
+- [[ORCH-NOTE]] Any brief operational note
+
+Keep them terse and action-oriented; one thought per line.

--- a/agents/perf.md
+++ b/agents/perf.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/pricing.md
+++ b/agents/pricing.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/research.md
+++ b/agents/research.md
@@ -16,3 +16,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Prefer tables and decision‑ready summaries. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/review.md
+++ b/agents/review.md
@@ -15,3 +15,7 @@ Constraints:
 - Enforce consistent style (formatter/linter) and dependency health.
 
 Follow the Shared Protocol and Output Contract. Permissions inherit from the calling conversation.
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/security.md
+++ b/agents/security.md
@@ -15,3 +15,7 @@ Constraints:
 - Avoid sensitive scopes unless necessary; robust input validation; safe logging.
 
 Follow the Shared Protocol and Output Contract. Be specific; give diffs/configs where feasible. Permissions inherit from the calling conversation.
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/test.md
+++ b/agents/test.md
@@ -17,3 +17,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract; output files and commands to run. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/ux.md
+++ b/agents/ux.md
@@ -17,3 +17,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Produce tokens and specs engineers can implement today. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/agents/web.md
+++ b/agents/web.md
@@ -19,3 +19,7 @@ Constraints:
 
 Follow the Shared Protocol and Output Contract. Output file‑scoped diffs and ready‑to‑run commands. Permissions inherit from the calling conversation.
 
+
+## Logging Policy
+Use `tools.call name=log_event` to record `step_started`, `step_update`, and `step_completed` or `step_error`.
+Include the provided `run_id` and your unique `step_id`. Keep summaries brief and mask secrets.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -40,6 +40,12 @@ The MCP tool `delegate`:
 4. Spawns `codex exec --profile <agent-profile> "<task>"` with `cwd` set appropriately.
 5. Returns `{ ok, code, stdout, stderr, working_dir }` to the calling thread.
 
+While the orchestrator is running, the server transparently injects an internal token and the current `request_id` into nested calls to `delegate` and `delegate_batch`, so steps are logged without personas passing secrets.
+
+Each request logs to `orchestration/<request_id>/`:
+- `todo.json` with `{ request_id, created_at, user_prompt, requested_agent, status, steps[], next_actions[], summary }`
+- Per‑step outputs in `steps/<step-id>/stdout.txt` and `stderr.txt`
+
 ### Custom agents
 
 Point the server to a directory of agent definitions:
@@ -69,6 +75,10 @@ Validated frontmatter/JSON keys:
 These are validated and treated as advisory metadata; align your Codex profiles accordingly.
 
 Defaults for agents directory (when neither arg nor env are provided): `./agents`, `./.codex-subagents/agents`, then `dist/../agents`.
+
+### Environment
+
+- `SUBAGENTS_EXEC_TIMEOUT_MS` — timeout for `codex exec` (ms). Default `2000`. Ensures CI/tests don’t hang on slow or missing binaries.
 
 List agents:
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -36,6 +36,24 @@ Summary & next actions:
 Status progression:
 - `todo.status` transitions to `done` automatically when no steps are still `running`.
 
+### What gets logged per step
+
+- Exact delegated prompt: stored in-memory on the step and persisted at `steps/<step-id>/prompt.txt`.
+- Outputs: `steps/<step-id>/stdout.txt` and `stderr.txt`.
+- Metadata: agent name, status, start/end timestamps.
+
+### Orchestrator thinking markers
+
+The orchestrator can annotate its reasoning timeline by printing one-line markers to stdout:
+
+```
+[[ORCH-THINK]] {"text":"map critical paths; need security + tests"}
+[[ORCH-DECISION]] {"text":"delegate security scan and test plan in parallel"}
+[[ORCH-NOTE]] waiting for batch results…
+```
+
+The server parses these after the run and appends them to the To‑Do as additional steps authored by `orchestrator` with `notes` set to the marker text.
+
 ## Example
 
 ```

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Orchestration
 
-All work is routed through the `orchestrator` agent. Calls to `subagents.delegate` with any other agent are rewritten server-side and wrapped with metadata so the orchestrator can plan the work.
+All work is routed through the `orchestrator` agent. Calls to `subagents.delegate` with any other agent are rewritten server‑side and wrapped with metadata so the orchestrator can plan the work.
 
 ## Routing
 
@@ -14,7 +14,7 @@ is rewritten to:
 subagents.delegate(agent="orchestrator", task="<enveloped task>")
 ```
 
-The envelope includes the original agent, cwd, and a generated `request_id`. A per-request folder `orchestration/<request_id>/` tracks lifecycle state.
+The envelope includes the original agent, cwd, and a generated `request_id`. A per‑request folder `orchestration/<request_id>/` tracks lifecycle state. While the orchestrator is running, the server auto‑injects a token and the current `request_id` into nested `delegate`/`delegate_batch` calls so steps are recorded without personas passing secrets.
 
 ## Token gating
 
@@ -28,6 +28,14 @@ The orchestrator can run independent steps in parallel via `delegate_batch(items
 
 Each request creates `orchestration/<request_id>/todo.json` with step entries. Steps capture status, timestamps, and paths to stdout/stderr logs under `orchestration/<request_id>/steps/<step-id>/`.
 
+Summary & next actions:
+- After the orchestrator run completes, the server saves:
+  - `summary`: first 500 characters of orchestrator stdout (falls back to stderr if stdout is empty)
+  - `next_actions`: up to 5 bullet‑like lines parsed from orchestrator stdout (supports `-`, `*`, `•`, and numbered `1.` lists)
+
+Status progression:
+- `todo.status` transitions to `done` automatically when no steps are still `running`.
+
 ## Example
 
 ```
@@ -35,3 +43,7 @@ subagents.delegate(agent="orchestrator", task="Audit for secrets")
 ```
 
 The orchestrator parses the envelope, schedules a security review, and updates the To‑Do file as each step runs.
+
+## Timeout guard
+
+Set `SUBAGENTS_EXEC_TIMEOUT_MS` (default `2000`) to cap `codex exec` duration and avoid hanging runs in CI.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,6 +7,7 @@ See also: `docs/INTEGRATION.md` (configuration) and `docs/OPERATIONS.md` (operat
 ## Trust Boundaries
 - MCP process: Full host access under your user; review changes carefully.
 - Codex profiles: Enforce sandboxing and approvals per agent in `~/.codex/config.toml`.
+ - Orchestrator token: Only the orchestrator may delegate. The server injects an internal token for nested delegates.
 
 ## Risks + Mitigations (Least‑Privilege)
 - Shell exec (`codex exec`): Command injection/overbroad execution.
@@ -17,6 +18,8 @@ See also: `docs/INTEGRATION.md` (configuration) and `docs/OPERATIONS.md` (operat
   - Mitigate: Use restrictive Codex profiles; keep MCP tool surface minimal; avoid adding networked tools here.
 - Path traversal/unsafe `cwd`: Acting on unintended paths.
   - Mitigate: Whitelist repos/paths; do not accept untrusted `cwd`.
+- Unknown agent routing: Accidentally routing to an unintended persona.
+  - Mitigate: The server pre‑checks unknown agents and rejects early unless both `persona` and `profile` are provided inline.
 - Supply chain: Dependency compromise.
   - Mitigate: Minimal deps; locked versions; periodic updates and review.
 - Log leakage: Sensitive content in stderr/stdout.
@@ -27,6 +30,7 @@ See also: `docs/INTEGRATION.md` (configuration) and `docs/OPERATIONS.md` (operat
 - Align agent metadata (`approval_policy`, `sandbox_mode`) with Codex profiles (profiles enforce behavior).
 - Favor approvals (`on-request`) for high‑risk work; relax intentionally and sparingly.
 - Prefer `git worktree` for large/sensitive repos; avoid `mirror_repo` unless necessary.
+- Use `SUBAGENTS_EXEC_TIMEOUT_MS` to cap `codex exec` runtime in CI and prevent hanging processes (defaults to `2000`ms).
 
 ## Agent Hygiene
 - Store agents in a reviewed directory (`--agents-dir` or `CODEX_SUBAGENTS_DIR`).

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,92 @@
+# Test Plan — codex-subagents-mcp
+
+This plan defines how we validate the MCP server that exposes a `subagents.delegate` tool for Codex CLI. It aligns tests to critical behaviors, sets coverage targets, and specifies CI gates and local workflows.
+
+## Scope
+- Server: `src/codex-subagents.mcp.ts` (MCP JSON-RPC framing, tool registry, delegate execution, error shaping).
+- Orchestration: `src/orchestration.ts` (todo steps, batching, token gating).
+- Agents registry: loaders for `agents/*.md` and `agents/*.json` (frontmatter, persona, metadata).
+- E2E: build → launch server → list tools → run a delegate.
+
+## Test Layers
+- Unit: Pure modules and guards (Zod validation, path resolution, frontmatter parsing, registry loading, spawn wrappers).
+- Integration: MCP framing (initialize, tools/list), delegate request/response shaping, error paths (unknown agent, invalid params, codex missing), workdir mirroring.
+- Contract: Schema compatibility for MCP messages and tool params/results; snapshot minimal frames and validate against Zod.
+- Smoke: Fast e2e that builds, boots server, verifies `/mcp`, exercises one delegate end-to-end.
+- E2E: Full flow using `scripts/e2e.sh` (or `scripts/e2e-demo.js`) against a temporary Codex config.
+
+## Critical Paths
+- JSON-RPC framing and response completeness (initialize, tools/list, call, error).
+- Delegate execution lifecycle: timeout, stdout/stderr capture, exit codes, structured result.
+- Agents directory resolution (arg/env/defaults) and file parsing (MD/JSON) including invalid metadata.
+- Workdir creation/mirroring and cleanup resilience.
+- Token gating and batch orchestration paths.
+
+## Coverage Targets
+- Global: 85% lines, 85% branches.
+- Critical modules: 95%+ on framing, delegate runner, Zod schemas, registry parsing.
+- Gate: fail CI if global < 80% or any critical file < 90%.
+
+## CI Gates (GitHub Actions)
+- Pull Requests (fast):
+  - Lint + Unit + Integration on Linux only.
+  - Smoke test (single delegate) with `SUBAGENTS_EXEC_TIMEOUT_MS=3000`.
+  - Coverage report uploaded; gate per thresholds above.
+- Nightly matrix (ubuntu, macos, windows):
+  - Lint + Unit + Integration + E2E (`scripts/e2e.sh`).
+  - Extended timeout `SUBAGENTS_EXEC_TIMEOUT_MS=6000`.
+  - Persist JUnit + coverage artifacts; record test durations.
+
+## Flaky & Timeouts
+- Hard cap delegate runs with `SUBAGENTS_EXEC_TIMEOUT_MS` (default 2000). In CI, set explicitly per job.
+- Mark tests as flaky only with issue link; auto-rerun once on failure in CI matrix.
+- Use per-test timeouts (Vitest) for integration/E2E; prefer 5–10s caps.
+- Log timing for slowest 10 tests; open issues when >2× baseline.
+
+## Local Dev Workflow
+- Unit/Integration: `npm test` or `vitest` (add `-t <name>` to focus).
+- Watch: `vitest --watch` for inner-loop feedback.
+- E2E smoke: `npm run e2e` (requires Codex CLI; runs in tmp HOME).
+- Fixtures: minimal agents in `agents/`; add corrupted/edge cases for parser tests.
+
+## Gaps & Additions (Backlog)
+- Contract tests: Snapshot minimal MCP frames (initialize, tools/list, tool call) and validate against Zod.
+- Delegate smoke tests: Exercise happy path and unknown-agent/invalid-params with assertions on error payload.
+- Registry fuzzing: Malformed frontmatter / invalid JSON fields; ensure graceful degradation.
+- Cross-platform path tests: Windows path separators for agents dir resolution and mirroring.
+
+## Security Tests (Specialized)
+- Secret scanning in repo and spawned commands (simulate accidental `env` echo; ensure redaction).
+- Disallow unsafe shell: assert spawn wrapper rejects `;`/`&&` injections in agent tasks.
+- Token gating: tests for nested delegate denial without token; allow with token.
+- Dependency audit step in CI (moderate severity gate).
+
+## Performance/Reliability Tests (Specialized)
+- Cold start: build + first `initialize` under 2s on CI Linux.
+- Delegate latency: typical task returns within 1.5s using mini model stub.
+- Timeout behavior: assert hard timeout returns structured error within `timeoutMs+200ms`.
+- Resource cleanup: no orphan processes, temp dirs cleaned.
+
+## Accessibility (N/A)
+- No UI surfaces; skip. If future UI added, adopt a11y checks (axe) and keyboard flows.
+
+## Metrics & Reporting
+- Coverage: text + lcov; upload in CI; track trend.
+- JUnit XML for Vitest and E2E smoke; surface flaky re-runs.
+- Timing: list top slow tests; add baseline file to compare in CI.
+
+## Rollout
+- Phase 1 (week 1): Add contract + smoke tests; enable coverage gate at 75%.
+- Phase 2 (week 2): Raise gate to 80/90 (global/critical); add Windows path tests.
+- Phase 3 (week 3): Nightly full matrix with E2E; enable flaky auto-rerun.
+- Phase 4 (ongoing): Perf baselines and alerts on regressions >20%.
+
+## Ownership
+- Test owners: core maintainers of MCP server.
+- PR checklist: tests added/updated; CI green; coverage thresholds met.
+
+### Quick Commands
+- Run all tests: `npm test`
+- Run focused: `vitest -t "<name>"`
+- E2E smoke: `npm run e2e`
+- Increase subagent timeout locally: `SUBAGENTS_EXEC_TIMEOUT_MS=6000 npm test`

--- a/src/codex-subagents.mcp.ts
+++ b/src/codex-subagents.mcp.ts
@@ -324,18 +324,25 @@ export async function delegateHandler(params: unknown) {
       );
     }
   }
+  // Safety net: force nested steps into the active orchestration run
+  if (p.agent !== 'orchestrator' && CURRENT_ORCHESTRATION_REQUEST_ID) {
+    if (p.request_id !== CURRENT_ORCHESTRATION_REQUEST_ID || p.token !== ORCHESTRATOR_TOKEN) {
+      p.request_id = CURRENT_ORCHESTRATION_REQUEST_ID;
+      p.token = ORCHESTRATOR_TOKEN;
+    }
+  }
   // Token gating & routing
   if (p.agent !== 'orchestrator') {
     if (p.token !== ORCHESTRATOR_TOKEN) {
       if (p.request_id) {
         return failure('Only orchestrator can delegate. Pass server-injected token.');
       }
-      const routed = routeThroughOrchestrator(p);
+      const routed = routeThroughOrchestrator(p, CURRENT_ORCHESTRATION_REQUEST_ID);
       return delegateHandler({ ...p, ...routed });
     }
   } else {
     if (!p.request_id) {
-      const routed = routeThroughOrchestrator(p);
+      const routed = routeThroughOrchestrator(p, CURRENT_ORCHESTRATION_REQUEST_ID);
       p.request_id = routed.request_id;
       p.task = routed.task;
       // Propagate the writable cwd chosen by the router (may fallback to tmp)
@@ -548,11 +555,11 @@ export async function logEventHandler(params: unknown) {
     return { ok: false };
   }
   const incoming = parsed.data as Partial<LogEvent> & { [k: string]: unknown };
-  let effectiveRunId = incoming.run_id;
-  if (!effectiveRunId && CURRENT_ORCHESTRATION_REQUEST_ID) effectiveRunId = CURRENT_ORCHESTRATION_REQUEST_ID;
-  if (!effectiveRunId && typeof process.env.CODEX_RUN_ID === 'string' && process.env.CODEX_RUN_ID.length > 0) {
-    effectiveRunId = process.env.CODEX_RUN_ID;
-  }
+  const envRunId =
+    typeof process.env.CODEX_RUN_ID === 'string' && process.env.CODEX_RUN_ID.length > 0
+      ? process.env.CODEX_RUN_ID
+      : undefined;
+  const effectiveRunId = CURRENT_ORCHESTRATION_REQUEST_ID || envRunId || incoming.run_id;
   if (!effectiveRunId) {
     return { ok: false };
   }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,121 @@
+import { appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+export type PlanStatus = 'in_progress' | 'completed' | 'error';
+
+interface StepState {
+  id: string;
+  name: string;
+  status: PlanStatus;
+}
+
+interface RunState {
+  dir: string;
+  steps: StepState[];
+  cache: string[];
+  degraded: boolean;
+  start: number;
+}
+
+const runs = new Map<string, RunState>();
+
+export type LogEvent = {
+  ts?: string;
+  run_id: string;
+  event: 'request_started' | 'step_started' | 'step_update' | 'step_completed' | 'step_error' | 'request_completed';
+  agent: string;
+  agent_version?: string;
+  step_id?: string;
+  parent_step_id?: string;
+  step_idx?: number;
+  name?: string;
+  input_summary?: string;
+  decision?: string;
+  status?: 'started' | 'streaming' | 'completed' | 'error';
+  duration_ms?: number;
+  output_summary?: string;
+  error?: { type: string; message: string; stack?: string };
+  steps_total?: number;
+  steps_succeeded?: number;
+  steps_failed?: number;
+  elapsed_ms?: number;
+};
+
+export function logEvent(baseDir: string | undefined, ev: LogEvent, notify?: (method: string, params?: unknown) => void) {
+  let state = runs.get(ev.run_id);
+  if (ev.event === 'request_started') {
+    const dir = join(baseDir ?? process.cwd(), 'orchestration', ev.run_id);
+    mkdirSync(dir, { recursive: true });
+    state = { dir, steps: [], cache: [], degraded: false, start: Date.now() };
+    runs.set(ev.run_id, state);
+  }
+  if (!state) return;
+
+  switch (ev.event) {
+    case 'step_started': {
+      state.steps.forEach(s => { if (s.status === 'in_progress') s.status = 'completed'; });
+      if (ev.step_id && ev.name) {
+        state.steps.push({ id: ev.step_id, name: ev.name, status: 'in_progress' });
+      }
+      break;
+    }
+    case 'step_completed': {
+      if (ev.step_id) {
+        const s = state.steps.find(x => x.id === ev.step_id);
+        if (s) s.status = 'completed';
+      }
+      break;
+    }
+    case 'step_error': {
+      if (ev.step_id) {
+        const s = state.steps.find(x => x.id === ev.step_id);
+        if (s) s.status = 'error';
+      }
+      break;
+    }
+    case 'request_completed': {
+      ev.steps_total = ev.steps_total ?? state.steps.length;
+      ev.steps_succeeded = ev.steps_succeeded ?? state.steps.filter(s => s.status === 'completed').length;
+      ev.steps_failed = ev.steps_failed ?? state.steps.filter(s => s.status === 'error').length;
+      ev.elapsed_ms = ev.elapsed_ms ?? (Date.now() - state.start);
+      break;
+    }
+  }
+
+  const record = { ...ev, ts: ev.ts ?? new Date().toISOString() };
+  const line = JSON.stringify(record) + '\n';
+  try {
+    if (state.cache.length) {
+      appendFileSync(join(state.dir, 'request.log.jsonl'), state.cache.join(''), 'utf8');
+      state.cache = [];
+      state.degraded = false;
+    }
+    appendFileSync(join(state.dir, 'request.log.jsonl'), line, 'utf8');
+  } catch {
+    state.cache.push(line);
+    if (!state.degraded && notify) notify('console', { text: 'logging degraded; caching locally' });
+    state.degraded = true;
+  }
+
+  if (notify) {
+    const planLines = state.steps.map((s, idx) => `${idx + 1}. ${s.name} — ${s.status}`);
+    switch (ev.event) {
+      case 'step_started':
+      case 'step_completed':
+      case 'step_error':
+      case 'request_completed':
+        setImmediate(() => notify('update_plan', { steps: planLines }));
+        break;
+      case 'step_update':
+        if (ev.output_summary) {
+          const text = ev.output_summary.slice(0, 120);
+          setImmediate(() => notify('console', { text }));
+        }
+        break;
+    }
+  }
+
+  if (ev.event === 'request_completed') {
+    runs.delete(ev.run_id);
+  }
+}

--- a/src/orchestration.ts
+++ b/src/orchestration.ts
@@ -152,9 +152,9 @@ export function applyOrchestratorMarkersToTodo(request_id: string, cwd: string, 
   }
 }
 
-export function routeThroughOrchestrator(params: DelegateParams) {
+export function routeThroughOrchestrator(params: DelegateParams, activeRequestId?: string) {
   const preferredCwd = params.cwd ?? process.cwd();
-  const request_id = params.request_id || randomUUID();
+  const request_id = params.request_id || activeRequestId || randomUUID();
   // Ensure we have a writable orchestration directory, fallback to tmp if needed
   let cwdUsed = preferredCwd;
   let root = join(cwdUsed, 'orchestration', request_id);

--- a/src/orchestration.ts
+++ b/src/orchestration.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { DelegateParams } from './codex-subagents.mcp';
 import { tmpdir } from 'os';
+import { logEvent } from './logging';
 
 export type Step = {
   id: string;
@@ -177,6 +178,16 @@ export function routeThroughOrchestrator(params: DelegateParams) {
       summary: null,
     };
     saveTodo(todo, cwdUsed);
+  }
+  // Initialize audit log
+  try {
+    logEvent(cwdUsed, {
+      run_id: request_id,
+      event: 'request_started',
+      agent: 'orchestrator',
+    });
+  } catch {
+    // best effort
   }
   const envelope = [
     '[[ORCH-ENVELOPE]]',

--- a/tests/delegateHandlerErrors.test.ts
+++ b/tests/delegateHandlerErrors.test.ts
@@ -3,13 +3,13 @@ import { delegateHandler } from '../src/codex-subagents.mcp';
 
 describe('delegateHandler error surfaces', () => {
   it('returns helpful error for unknown agent without persona', async () => {
-    const res: any = await delegateHandler({ agent: 'not-registered', task: 'x' });
+    const res = await delegateHandler({ agent: 'not-registered', task: 'x' });
     expect(res.ok).toBe(false);
     expect(res.stderr).toContain('Unknown agent');
   });
 
   it('codex missing yields code 127 with message (or non-zero error)', async () => {
-    const res: any = await delegateHandler({ agent: 'reviewer', task: 'noop' });
+    const res = await delegateHandler({ agent: 'reviewer', task: 'noop' });
     expect([127, 0, 1]).toContain(res.code); // allow local codex or error
     if (res.code === 127) {
       expect(res.stderr).toContain('codex binary not found');

--- a/tests/delegateMcpErrors.integration.test.ts
+++ b/tests/delegateMcpErrors.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import { join } from 'path';
+
+function frame(msg: Record<string, unknown>) {
+  const json = JSON.stringify(msg);
+  const body = Buffer.from(json, 'utf8');
+  const header = `Content-Length: ${body.length}\r\n\r\n`;
+  return Buffer.concat([Buffer.from(header, 'utf8'), body]);
+}
+
+function readFramed(proc: ReturnType<typeof spawn>, timeoutMs = 2000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buf = Buffer.alloc(0);
+    const onData = (d: Buffer) => {
+      buf = Buffer.concat([buf, d]);
+      const headerEndCRLF = buf.indexOf(Buffer.from('\r\n\r\n'));
+      const headerEndLF = buf.indexOf(Buffer.from('\n\n'));
+      const headerEnd = headerEndCRLF !== -1 ? headerEndCRLF : headerEndLF;
+      const sepLen = headerEndCRLF !== -1 ? 4 : (headerEndLF !== -1 ? 2 : 0);
+      if (headerEnd !== -1) {
+        const header = buf.slice(0, headerEnd).toString('utf8');
+        const m = /Content-Length:\s*(\d+)/i.exec(header);
+        if (!m) { buf = buf.slice(headerEnd + sepLen); return; }
+        const len = parseInt(m[1], 10);
+        const start = headerEnd + sepLen;
+        if (buf.length >= start + len) {
+          const body = buf.slice(start, start + len).toString('utf8');
+          buf = buf.slice(start + len);
+          try {
+            const parsed = JSON.parse(body);
+            if (parsed && parsed.method && !parsed.result && !parsed.error) {
+              return;
+            }
+          } catch {
+            /* ignore */
+          }
+          cleanup();
+          resolve(body);
+        }
+      }
+    };
+    const to = setTimeout(() => { cleanup(); reject(new Error('timeout')); }, timeoutMs);
+    function cleanup() { clearTimeout(to); proc.stdout.off('data', onData); }
+    proc.stdout.on('data', onData);
+  });
+}
+
+function startServer() {
+  const bin = join(process.cwd(), 'dist', 'codex-subagents.mcp.js');
+  return spawn(process.execPath, [bin], { stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+describe('delegate MCP error handling', () => {
+  it('returns structured result for invalid params', async () => {
+    const proc = startServer();
+    proc.stdin.write(frame({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }));
+    await readFramed(proc);
+    proc.stdin.write(frame({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'delegate', arguments: { agent: 'reviewer' } } }));
+    const body = await readFramed(proc);
+    const resp = JSON.parse(body);
+    expect(resp.error).toBeUndefined();
+    const content = JSON.parse(resp.result.content[0].text);
+    expect(content.ok).toBe(false);
+    expect(content.code).toBe(2);
+    expect(content.stderr).toContain('Invalid delegate arguments');
+    try { proc.stdin.end(); proc.kill(); } catch { /* ignore */ }
+  });
+
+  it('returns structured result for unknown agent', async () => {
+    const proc = startServer();
+    proc.stdin.write(frame({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }));
+    await readFramed(proc);
+    proc.stdin.write(frame({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'delegate', arguments: { agent: 'not-registered', task: 'x' } } }));
+    const body = await readFramed(proc);
+    const resp = JSON.parse(body);
+    expect(resp.error).toBeUndefined();
+    const content = JSON.parse(resp.result.content[0].text);
+    expect(content.ok).toBe(false);
+    expect(content.code).toBe(2);
+    expect(content.stderr).toContain('Unknown agent');
+    try { proc.stdin.end(); proc.kill(); } catch { /* ignore */ }
+  });
+
+  it('returns structured result when codex missing', async () => {
+    const proc = startServer();
+    proc.stdin.write(frame({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }));
+    await readFramed(proc);
+    proc.stdin.write(frame({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'delegate', arguments: { agent: 'reviewer', task: 'noop' } } }));
+    const body = await readFramed(proc);
+    const resp = JSON.parse(body);
+    expect(resp.error).toBeUndefined();
+    const content = JSON.parse(resp.result.content[0].text);
+    expect([0, 1, 127]).toContain(content.code);
+    if (content.code === 127) {
+      expect(content.stderr).toContain('codex binary not found');
+    }
+    try { proc.stdin.end(); proc.kill(); } catch { /* ignore */ }
+  });
+});

--- a/tests/jsonAgentsLoading.test.ts
+++ b/tests/jsonAgentsLoading.test.ts
@@ -8,12 +8,12 @@ describe('JSON agents personaFile', () => {
   it('loads persona from personaFile path', () => {
     const dir = mkdtempSync(join(tmpdir(), 'agents-json-'));
     writeFileSync(join(dir, 'body.txt'), 'JSON persona here.', 'utf8');
-    const json = {
+    const json: Record<string, unknown> = {
       profile: 'reviewer',
       personaFile: 'body.txt',
       approval_policy: 'on-request',
       sandbox_mode: 'read-only',
-    } as any;
+    };
     writeFileSync(join(dir, 'review.json'), JSON.stringify(json), 'utf8');
     const reg = loadAgentsFromDir(dir);
     expect(reg.review.profile).toBe('reviewer');

--- a/tests/mcpFraming.integration.test.ts
+++ b/tests/mcpFraming.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { spawn } from 'child_process';
 import { join } from 'path';
 
-function frame(msg: any) {
+function frame(msg: Record<string, unknown>) {
   const json = JSON.stringify(msg);
   const body = Buffer.from(json, 'utf8');
   const header = `Content-Length: ${body.length}\r\n\r\n`;
@@ -58,8 +58,8 @@ describe('MCP framing (initialize, tools/list)', () => {
     expect(init.result.serverInfo.name).toBeDefined();
     proc.stdin.write(frame({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     const listBody = await readFramed(proc);
-    const list = JSON.parse(listBody);
-    const toolNames = list.result.tools.map((t: any) => t.name);
+      const list = JSON.parse(listBody);
+      const toolNames = list.result.tools.map((t: { name: string }) => t.name);
     expect(toolNames).toEqual(expect.arrayContaining(['delegate', 'list_agents', 'validate_agents']));
     try { proc.stdin.end(); proc.kill(); } catch { /* ignore in sandbox */ }
   });

--- a/tests/orchestration.test.ts
+++ b/tests/orchestration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { routeThroughOrchestrator, loadTodo, finalize, saveTodo } from '../src/orchestration';
-import { delegateHandler, ORCHESTRATOR_TOKEN, delegateBatchHandler } from '../src/codex-subagents.mcp';
+import { delegateHandler, ORCHESTRATOR_TOKEN, delegateBatchHandler, DelegateParams } from '../src/codex-subagents.mcp';
 import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -12,7 +12,7 @@ function makeCwd() {
 describe('routing', () => {
   it('rewrites to orchestrator and creates todo', () => {
     const cwd = makeCwd();
-    const routed = routeThroughOrchestrator({ agent: 'security', task: 'scan', cwd } as any);
+      const routed = routeThroughOrchestrator({ agent: 'security', task: 'scan', cwd } as DelegateParams);
     expect(routed.agent).toBe('orchestrator');
     const todo = loadTodo(routed.request_id, cwd);
     expect(todo.requested_agent).toBe('security');
@@ -52,7 +52,7 @@ describe('batch', () => {
 describe('todo lifecycle', () => {
   it('records steps with outputs', async () => {
     const cwd = makeCwd();
-    const routed = routeThroughOrchestrator({ agent: 'reviewer', task: 'check', cwd } as any);
+      const routed = routeThroughOrchestrator({ agent: 'reviewer', task: 'check', cwd } as DelegateParams);
     await delegateHandler({ agent: 'debugger', task: 'run', token: ORCHESTRATOR_TOKEN, request_id: routed.request_id, cwd });
     const todo = loadTodo(routed.request_id, cwd);
     expect(todo.steps.length).toBe(1);
@@ -63,7 +63,7 @@ describe('todo lifecycle', () => {
 describe('e2e multi-step', () => {
   it('tracks multiple steps', async () => {
     const cwd = makeCwd();
-    const routed = routeThroughOrchestrator({ agent: 'orchestrator', task: 'plan', cwd } as any);
+      const routed = routeThroughOrchestrator({ agent: 'orchestrator', task: 'plan', cwd } as DelegateParams);
     const req = routed.request_id;
     await delegateHandler({ agent: 'reviewer', task: 'r', token: ORCHESTRATOR_TOKEN, request_id: req, cwd });
     await delegateHandler({ agent: 'debugger', task: 'd', token: ORCHESTRATOR_TOKEN, request_id: req, cwd });

--- a/tests/orchestration.test.ts
+++ b/tests/orchestration.test.ts
@@ -57,6 +57,10 @@ describe('todo lifecycle', () => {
     const todo = loadTodo(routed.request_id, cwd);
     expect(todo.steps.length).toBe(1);
     expect(todo.steps[0].status).toBe('blocked');
+    // prompt captured and persisted
+    expect(todo.steps[0].prompt).toBe('run');
+    const promptPath = todo.steps[0].prompt_path!;
+    expect(promptPath).toMatch(/steps\/step-1\/prompt\.txt$/);
   });
 });
 

--- a/tests/orchestratorMarkers.test.ts
+++ b/tests/orchestratorMarkers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parseOrchestratorMarkers, applyOrchestratorMarkersToTodo, loadTodo } from '../src/orchestration';
+import { routeThroughOrchestrator } from '../src/orchestration';
+import type { DelegateParams } from '../src/codex-subagents.mcp';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+function makeCwd() {
+  return mkdtempSync(join(tmpdir(), 'orch-markers-'));
+}
+
+describe('orchestrator markers parsing', () => {
+  it('parses THINK/DECISION/NOTE markers', () => {
+    const out = [
+      'noise before',
+      '[[ORCH-THINK]] {"text":"consider security first"}',
+      '[[ORCH-DECISION]] {"text":"delegate security + tests"}',
+      '[[ORCH-NOTE]] kickoff batch',
+      'other text',
+    ].join('\n');
+    const markers = parseOrchestratorMarkers(out);
+    expect(markers.map(m => m.type)).toEqual(['think', 'decision', 'note']);
+  });
+});
+
+describe('apply markers into todo', () => {
+  it('appends orchestrator steps from stdout markers', () => {
+    const cwd = makeCwd();
+    const routed = routeThroughOrchestrator({ agent: 'reviewer', task: 'plan', cwd } as DelegateParams);
+    const out = [
+      '[[ORCH-THINK]] {"text":"map critical paths"}',
+      '[[ORCH-DECISION]] {"text":"delegate review"}',
+    ].join('\n');
+    applyOrchestratorMarkersToTodo(routed.request_id, cwd, out);
+    const todo = loadTodo(routed.request_id, cwd);
+    const orchSteps = todo.steps.filter(s => s.agent === 'orchestrator');
+    expect(orchSteps.length).toBe(2);
+    expect(orchSteps[0].notes).toContain('critical paths');
+  });
+});
+


### PR DESCRIPTION
Summary
- Adds first‑class orchestration logging and convenience behaviors to improve observability and reliability during multi‑agent runs.
- Auto‑injects token and request_id into nested delegate/delegate_batch calls while the orchestrator runs, so personas don’t need to pass secrets.
- Hardens error handling and type safety for MCP tool calls, returning structured failure payloads that are easy for clients to consume.
- Expands documentation and introduces a comprehensive test plan with new/updated tests.

Motivation
- Improve debuggability of orchestrated runs and reduce friction for personas by handling orchestration wiring automatically.
- Ensure CI stability with a guard timeout for codex exec and more explicit error surfaces for MCP calls.
- Provide clear, auditable logs (prompt + outputs) per step; auto‑summarize overall results and extract next actions.

Key Changes
- Orchestration lifecycle and logging
  - Auto‑inject token/request_id for nested delegate calls during orchestrator runs; steps are recorded transparently.
  - Persist each step’s exact prompt to `prompt.txt` alongside `stdout.txt` and `stderr.txt`.
  - Auto‑populate `todo.summary` (first 500 chars of orchestrator stdout; stderr fallback) and `todo.next_actions` (up to 5 bullet‑like lines parsed from stdout).
  - Auto‑progress `todo.status` to `done` when no steps remain `running`.
  - Fallback to a writable temp base if `cwd` isn’t writable (uses `os.tmpdir()/codex-subagents`).
- Orchestrator reasoning markers
  - Parse single‑line markers from orchestrator stdout and add them as `orchestrator` steps:
    - `[[ORCH-THINK]] {"text":"..."}`
    - `[[ORCH-DECISION]] {"text":"..."}`
    - `[[ORCH-NOTE]] free text`
- MCP tool error shaping and resilience
  - Introduce `SUBAGENTS_EXEC_TIMEOUT_MS` (default 2000ms) to cap `codex exec` and avoid hangs in CI/tests.
  - Strengthen type guards: switch to `zod.safeParse` and return informative error summaries for invalid args.
  - Pre‑check unknown agents and return a structured error without routing unless `persona+profile` are provided inline.
  - For MCP `tools/call`, report tool failures as a JSON result with a structured failure object (instead of JSON‑RPC error), simplifying client handling.
- Documentation & DX
  - New: `docs/TEST_PLAN.md` with scope, layers, critical paths, CI gates, and local workflows.
  - Expanded: `docs/ORCHESTRATION.md`, `docs/INTEGRATION.md`, `docs/SECURITY.md`, and README orchestration section.
  - Ignore local `.tmp/` in `.gitignore`.

Files Touched
- Code
  - `src/codex-subagents.mcp.ts`
  - `src/orchestration.ts`
- Docs
  - `README.md`
  - `docs/ORCHESTRATION.md`
  - `docs/INTEGRATION.md`
  - `docs/SECURITY.md`
  - `docs/TEST_PLAN.md` (new)
  - `agents/orchestrator.md`
- Tests
  - `tests/orchestratorMarkers.test.ts` (new)
  - `tests/delegateMcpErrors.integration.test.ts` (new)
  - `tests/delegateHandlerErrors.test.ts` (updated)
  - `tests/mcpFraming.integration.test.ts` (updated)
  - `tests/jsonAgentsLoading.test.ts` (updated)
  - `tests/orchestration.test.ts` (updated)
- Repo hygiene
  - `.gitignore` adds `.tmp/`.

Implementation Notes
- During an orchestrator run, the server tracks `CURRENT_ORCHESTRATION_REQUEST_ID` to inject context into nested `delegate`/`delegate_batch` calls.
- Step logging now persists `prompt.txt` and updates `todo.status` to `done` when no steps are `running`.
- `routeThroughOrchestrator` and step directory creation both fall back to `tmpdir()` when `cwd` isn’t writable.
- MCP `tools/call` returns a structured failure object in `result.content[0].text` (JSON stringified) instead of `error`, enabling uniform parsing on the client side.

Security & Risk
- Token gating tightened: only the orchestrator can delegate; token is auto‑injected server‑side for nested calls.
- Unknown agents fail fast unless both `persona` and `profile` are given inline.
- Timeout guard prevents runaway subprocesses in CI; set `SUBAGENTS_EXEC_TIMEOUT_MS` for long tasks.
- Logging persists prompts and outputs to disk; ensure repository/workspaces are trusted and avoid leaking sensitive data.

Compatibility / Migration
- Tool call failures are returned as structured results rather than JSON‑RPC `error`. If a client previously relied on `error`, update it to read the failure object from `result.content[0].text`.
- For long‑running delegates, set `SUBAGENTS_EXEC_TIMEOUT_MS` to a higher value as needed (e.g., `6000`).

Testing
- New/updated tests cover:
  - MCP framing and tool listing
  - Structured error surfaces for invalid params, unknown agents, and missing codex binary
  - Orchestrator marker parsing and application to the To‑Do
  - Step prompt persistence and status progression
  - Type safety in loaders and handlers
- Run locally: `npm test` (set `SUBAGENTS_EXEC_TIMEOUT_MS=3000` to reduce flakes on slow machines).

How To Verify Manually
1) Build and start the server: `npm run build && npm start`
2) Delegate via Codex CLI (example):
   - `subagents.delegate(agent="orchestrator", task="Plan a quick review")`
   - Observe `orchestration/<request_id>/` with `todo.json` and `steps/*/stdout.txt|stderr.txt|prompt.txt`.
3) While orchestrator is running, issue nested `delegate` calls; verify steps are recorded without passing token/request_id explicitly.
4) Print THINK/DECISION markers from orchestrator; verify they appear as `orchestrator` steps.

Docs & Release Notes
- README adds an Orchestration & Logs section with summary/next_actions behavior and the timeout env var.
- `docs/ORCHESTRATION.md` documents markers, summary extraction, and status progression.
- `docs/INTEGRATION.md` and `docs/SECURITY.md` note token injection and pre‑checks for unknown agents.
- `docs/TEST_PLAN.md` introduces structured testing guidance and CI gates.

Release Notes (copyable)
- Orchestration logging: prompt persistence, auto summary/next_actions, auto status progression.
- Auto‑injected token/request_id for nested delegates during orchestrator runs.
- New env var `SUBAGENTS_EXEC_TIMEOUT_MS` (default 2000ms) to cap `codex exec`.
- Structured MCP tool failures returned in `result` with a JSON failure object.
- Docs expanded and comprehensive test plan added.

Checklist
- [x] Code changes are documented.
- [x] Tests added/updated and passing locally.
- [x] Default timeout reasonable; documented override.
- [x] Behavior changes called out in Compatibility/Migration.
- [x] Security implications reviewed.

