### PR TITLE
Guard orchestration runs against spurious IDs

### DIFF
--- a/src/codex-subagents.mcp.ts
+++ b/src/codex-subagents.mcp.ts
@@ -324,18 +324,25 @@ export async function delegateHandler(params: unknown) {
       );
     }
   }
+  // Safety net: force nested steps into the active orchestration run
+  if (p.agent !== 'orchestrator' && CURRENT_ORCHESTRATION_REQUEST_ID) {
+    if (p.request_id !== CURRENT_ORCHESTRATION_REQUEST_ID || p.token !== ORCHESTRATOR_TOKEN) {
+      p.request_id = CURRENT_ORCHESTRATION_REQUEST_ID;
+      p.token = ORCHESTRATOR_TOKEN;
+    }
+  }
   // Token gating & routing
   if (p.agent !== 'orchestrator') {
     if (p.token !== ORCHESTRATOR_TOKEN) {
       if (p.request_id) {
         return failure('Only orchestrator can delegate. Pass server-injected token.');
       }
-      const routed = routeThroughOrchestrator(p);
+      const routed = routeThroughOrchestrator(p, CURRENT_ORCHESTRATION_REQUEST_ID);
       return delegateHandler({ ...p, ...routed });
     }
   } else {
     if (!p.request_id) {
-      const routed = routeThroughOrchestrator(p);
+      const routed = routeThroughOrchestrator(p, CURRENT_ORCHESTRATION_REQUEST_ID);
       p.request_id = routed.request_id;
       p.task = routed.task;
       // Propagate the writable cwd chosen by the router (may fallback to tmp)
@@ -548,11 +555,11 @@ export async function logEventHandler(params: unknown) {
     return { ok: false };
   }
   const incoming = parsed.data as Partial<LogEvent> & { [k: string]: unknown };
-  let effectiveRunId = incoming.run_id;
-  if (!effectiveRunId && CURRENT_ORCHESTRATION_REQUEST_ID) effectiveRunId = CURRENT_ORCHESTRATION_REQUEST_ID;
-  if (!effectiveRunId && typeof process.env.CODEX_RUN_ID === 'string' && process.env.CODEX_RUN_ID.length > 0) {
-    effectiveRunId = process.env.CODEX_RUN_ID;
-  }
+  const envRunId =
+    typeof process.env.CODEX_RUN_ID === 'string' && process.env.CODEX_RUN_ID.length > 0
+      ? process.env.CODEX_RUN_ID
+      : undefined;
+  const effectiveRunId = CURRENT_ORCHESTRATION_REQUEST_ID || envRunId || incoming.run_id;
   if (!effectiveRunId) {
     return { ok: false };
   }

--- a/src/orchestration.ts
+++ b/src/orchestration.ts
@@ -152,9 +152,9 @@ export function applyOrchestratorMarkersToTodo(request_id: string, cwd: string, 
   }
 }
 
-export function routeThroughOrchestrator(params: DelegateParams) {
+export function routeThroughOrchestrator(params: DelegateParams, activeRequestId?: string) {
   const preferredCwd = params.cwd ?? process.cwd();
-  const request_id = params.request_id || randomUUID();
+  const request_id = params.request_id || activeRequestId || randomUUID();
   // Ensure we have a writable orchestration directory, fallback to tmp if needed
   let cwdUsed = preferredCwd;
   let root = join(cwdUsed, 'orchestration', request_id);


### PR DESCRIPTION
## Summary
- Anchor all nested delegates to the active orchestration run, overriding mismatched request IDs or tokens

## Testing
- `npm run build`
- `npm test`
- `node` script simulating orchestrator with the prompt `use at least 3 specialized subagents to give me a review of my repository` and verifying a single `orchestration/<run_id>` directory
- `npx --yes @openai/codex exec -m`

------
https://chatgpt.com/codex/tasks/task_e_68b80eefa4088327af9695a5c9ed88ce